### PR TITLE
Fix compilation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ cd MNN
 mkdir build
 cmake .. # if using CUDA, add -DMNN_CUDA=ON
 make -j8
-cp -r include /path/to/ChatGLM-MNN/
+cp -r ../include /path/to/ChatGLM-MNN/
 cp libMNN.so /path/to/ChatGLM-MNN/libs
+cp express/libMNN_Express.so /path/to/ChatGLM-MNN/libs
 ```
 ### 2. Download Models
 从 `github release` 下载模型文件到 `/path/to/ChatGLM-MNN/resource/models`， 如下：


### PR DESCRIPTION
在ChatGLM-MNN目录下增加libs目录
MNN编译结束后include目录的路径有错，并且没有复制libMNN_Express.so（不确定这个文件是不是只有使用CUDA才有的）