### PR TITLE
Fix description in zh readme of resource/models/download_models.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ cp express/libMNN_Express.so /path/to/ChatGLM-MNN/libs
 从 `github release` 下载模型文件到 `/path/to/ChatGLM-MNN/resource/models`， 如下：
 ```
 cd resource/models
-./download_models_fp16.sh # 下载fp16权值模型
-./download_models_int8.sh # 下载int8权值模型，推荐使用
-./download_models_int4.sh # 下载int4权值模型，有精度损失
+./download_models.sh fp16 # 下载fp16权值模型
+./download_models.sh int8 # 下载int8权值模型，推荐使用
+./download_models.sh int4 # 下载int4权值模型，有精度损失
 ```
 
 ### 3. Build and Run


### PR DESCRIPTION
It seems that the shell script is updated but the zh readme is not.
